### PR TITLE
fix: Property checker fix

### DIFF
--- a/src/main/python/core/config_reader.py
+++ b/src/main/python/core/config_reader.py
@@ -112,7 +112,7 @@ class ConfigReader:
             default = 'missing'
             if isinstance(value, str):
                 if value.lower() == default:
-                    value = False
+                    value = None
                 else:
                     value = else_type(value)
             return value

--- a/src/main/python/core/global_manager.py
+++ b/src/main/python/core/global_manager.py
@@ -12,18 +12,18 @@ class CapiceManager:
         def __init__(self):
             self.property_checker = PropertyChecker()
             self._now = datetime.now()
-            self.overwrite_impute = False
-            self.overwrite_model = False
-            self.grch_build = False
-            self.config_grch_build = False
+            self.overwrite_impute = None
+            self.overwrite_model = None
+            self.grch_build = None
+            self.config_grch_build = None
             self.force = False
             self.verbose = False
             self.critical_logging_only = False
             self.annotation_features = []
             self.output_filename = ''
-            self.reference_genome = False
-            self.vep_version = False
-            self.config_vep_version = False
+            self.reference_genome = None
+            self.vep_version = None
+            self.config_vep_version = None
             self.config_loc = None
 
         @property
@@ -37,7 +37,8 @@ class CapiceManager:
         @overwrite_impute.setter
         def overwrite_impute(self, value=None):
             self.property_checker.check_property(value=value,
-                                                 expected_type=(str, bool))
+                                                 expected_type=str,
+                                                 include_none=True)
             self._overwrite_impute = value
 
         @property
@@ -47,7 +48,8 @@ class CapiceManager:
         @overwrite_model.setter
         def overwrite_model(self, value):
             self.property_checker.check_property(value=value,
-                                                 expected_type=(str, bool))
+                                                 expected_type=str,
+                                                 include_none=True)
             self._overwrite_model = value
 
         @property
@@ -57,7 +59,8 @@ class CapiceManager:
         @grch_build.setter
         def grch_build(self, value):
             self.property_checker.check_property(value=value,
-                                                 expected_type=(int, bool))
+                                                 expected_type=int,
+                                                 include_none=True)
             self._grch_build = value
 
         @property
@@ -72,7 +75,8 @@ class CapiceManager:
         @config_grch_build.setter
         def config_grch_build(self, value):
             self.property_checker.check_property(value=value,
-                                                 expected_type=(int, bool))
+                                                 expected_type=int,
+                                                 include_none=True)
             self._config_grch_build = value
 
         @property
@@ -131,7 +135,8 @@ class CapiceManager:
         @reference_genome.setter
         def reference_genome(self, value):
             self.property_checker.check_property(value=value,
-                                                 expected_type=(bool, str))
+                                                 expected_type=str,
+                                                 include_none=True)
             self._reference_genome = value
 
         @property
@@ -141,7 +146,8 @@ class CapiceManager:
         @vep_version.setter
         def vep_version(self, value):
             self.property_checker.check_property(value=value,
-                                                 expected_type=float)
+                                                 expected_type=float,
+                                                 include_none=True)
             self._vep_version = value
 
         @property
@@ -151,7 +157,8 @@ class CapiceManager:
         @config_vep_version.setter
         def config_vep_version(self, value):
             self.property_checker.check_property(value=value,
-                                                 expected_type=(float, bool))
+                                                 expected_type=float,
+                                                 include_none=True)
             self._config_vep_version = value
 
         @property

--- a/src/main/python/resources/checkers/input_version_checker.py
+++ b/src/main/python/resources/checkers/input_version_checker.py
@@ -59,7 +59,7 @@ class InputVersionChecker:
         globally later on in CAPICE.
         """
         self.manager.vep_version = self.export_vep_version
-        self.log.info('VEP version set to: {}'.format(self.export_vep_version))
+        self.log.info('VEP version set to: %s', self.export_vep_version)
 
     def _set_global_grch_build(self):
         """
@@ -67,7 +67,7 @@ class InputVersionChecker:
         be used globally later on in CAPICE.
         """
         self.manager.grch_build = self.export_grch_build
-        self.log.info('GRCh build set to: {}'.format(self.export_grch_build))
+        self.log.info('GRCh build set to: %s', self.export_grch_build)
 
     def _check_overrule(self):
         """
@@ -79,13 +79,14 @@ class InputVersionChecker:
         since it can not determine what file to use without VEP or
         GRCh argument.
         """
+
         impute = self.manager.overwrite_impute
         model = self.manager.overwrite_model
-        if impute is None or len(impute) == 0 and \
-                model is None or len(model) == 0:
+        if not impute and not model:  # Intended: empty string is also invalid
             error_message = (
-                'VEP version or GRCh build not specified and both overwrites are not\n' 
-                'set! Not able to find a correct impute or processing file!'
+                'VEP version or GRCh build not specified and both overwrites '
+                'are not set! '
+                'Not able to find a correct impute or processing file!'
             )
             self.log.critical(error_message)
             raise InputError(error_message)
@@ -128,7 +129,8 @@ class InputVersionChecker:
         passed.
         """
         self.log.warning(
-            f'Unable to obtain {type_of_check} version from file or config file!'
+            'Unable to obtain %s version from file or config file!',
+            type_of_check
         )
         self.check_overrule = True
 
@@ -144,8 +146,9 @@ class InputVersionChecker:
                 self.export_grch_build = argument
             else:
                 self.log.warning(
-                    f'Encountered an incorrect value for: {type_of_check} '
-                    f'({argument})'
+                    'Encountered an incorrect value for: %s (%s)',
+                    type_of_check,
+                    argument
                 )
 
     def _check_version_match(self):
@@ -185,18 +188,13 @@ class InputVersionChecker:
                                 version_file=None, match_successful=False):
         if match_successful:
             self.log.info(
-                'Successfully matched CLA and file versions for {}.'.format(
-                    type_of_mismatch
-                )
+                'Successfully matched CLA and file versions for %s.',
+                type_of_mismatch
             )
         else:
-            warning_message = """
-            Warning matching {} versions. 
-            CLA version supplied: 
-            {} does not match file version: {} !""".format(
-                type_of_mismatch,
-                version_cla,
-                version_file
-            ).strip()
+            warning_message = f"Warning matching {type_of_mismatch} " \
+                              f"versions. CLA version supplied: " \
+                              f"{version_cla} does not match file version: " \
+                              f"{version_file} !"
             warnings.warn(warning_message)
             self.log.warning(warning_message)

--- a/src/main/python/resources/checkers/input_version_checker.py
+++ b/src/main/python/resources/checkers/input_version_checker.py
@@ -79,8 +79,10 @@ class InputVersionChecker:
         since it can not determine what file to use without VEP or
         GRCh argument.
         """
-        if not self.manager.overwrite_impute and \
-                not self.manager.overwrite_model:
+        impute = self.manager.overwrite_impute
+        model = self.manager.overwrite_model
+        if impute is None or len(impute) == 0 and \
+                model is None or len(model) == 0:
             error_message = (
                 'VEP version or GRCh build not specified and both overwrites are not\n' 
                 'set! Not able to find a correct impute or processing file!'
@@ -136,10 +138,15 @@ class InputVersionChecker:
         :param argument: int or float
         """
         if argument:
-            if type_of_check == 'VEP':
+            if type_of_check == 'VEP' and argument > 0:
                 self.export_vep_version = argument
-            else:
+            elif type_of_check == 'GRCh' and argument > 0:
                 self.export_grch_build = argument
+            else:
+                self.log.warning(
+                    f'Encountered an incorrect value for: {type_of_check} '
+                    f'({argument})'
+                )
 
     def _check_version_match(self):
         """

--- a/src/main/python/resources/checkers/input_version_checker.py
+++ b/src/main/python/resources/checkers/input_version_checker.py
@@ -12,20 +12,20 @@ class InputVersionChecker:
     """
 
     def __init__(self,
-                 config_vep_version: float,
-                 file_vep_version: float,
-                 config_grch_build: int,
-                 file_grch_build: int):
+                 config_vep_version,
+                 file_vep_version,
+                 config_grch_build,
+                 file_grch_build):
         """
         Class to check the given VEP config argument and
         the header of the VEP file match.
-        :param config_vep_version: float,
+        :param config_vep_version: float or None,
             config argument for the used VEP version
-        :param file_vep_version: float,
+        :param file_vep_version: float or None,
             VEP version according to parsed input file
-        :param config_grch_build: int,
+        :param config_grch_build: int or None,
             config argument for the used GRCh build
-        :param file_grch_build: int,
+        :param file_grch_build: int or None,
             GRCh build according to parsed input file
         """
         self.config_vep_version = config_vep_version
@@ -79,8 +79,8 @@ class InputVersionChecker:
         since it can not determine what file to use without VEP or
         GRCh argument.
         """
-        if self.manager.overwrite_impute is False and \
-                self.manager.overwrite_model is False:
+        if not self.manager.overwrite_impute and \
+                not self.manager.overwrite_model:
             error_message = (
                 'VEP version or GRCh build not specified and both overwrites are not\n' 
                 'set! Not able to find a correct impute or processing file!'
@@ -111,8 +111,8 @@ class InputVersionChecker:
         :param to_check: list
         :param type_of_check: string
         """
-        if False in to_check:
-            if to_check.count(False) == len(to_check):
+        if None in to_check:
+            if to_check.count(None) == len(to_check):
                 self._turn_on_check_overrule(type_of_check=type_of_check)
             for argument in to_check:
                 self._apply_export_version(argument=argument,
@@ -135,7 +135,7 @@ class InputVersionChecker:
         Function to set the global VEP version or GRCh build.
         :param argument: int or float
         """
-        if argument is not False:
+        if argument:
             if type_of_check == 'VEP':
                 self.export_vep_version = argument
             else:

--- a/src/main/python/resources/checkers/property_checker.py
+++ b/src/main/python/resources/checkers/property_checker.py
@@ -26,11 +26,10 @@ class PropertyChecker:
             self._raise_type_error(expected_type, value)
 
     def _raise_type_error(self, expected_type, value):
-        error_message = f"Expected variable type " \
-                        f"{expected_type} but got {type(value)}"
-        self._talk_to_logger(error_message)
-        raise TypeError(error_message)
+        error_message = "Expected variable type %s but got %s"
+        self._talk_to_logger(error_message, expected_type, value)
+        raise TypeError(error_message % (expected_type, value))
 
     @abstractmethod
-    def _talk_to_logger(self, error_message):
+    def _talk_to_logger(self, msg, *args, **kwargs):
         pass

--- a/src/main/python/resources/checkers/property_checker.py
+++ b/src/main/python/resources/checkers/property_checker.py
@@ -14,11 +14,15 @@ class PropertyChecker:
         if not isinstance(value, expected_type):
             if include_none:
                 if value is not None:
-                    error_message = """
-                    Expected variable type {} but got {}
-                    """.format(expected_type, type(value)).strip()
-                    self._talk_to_logger(error_message=error_message)
-                    raise TypeError(error_message)
+                    self._raise_type_error(expected_type, value)
+            else:
+                self._raise_type_error(expected_type, value)
+
+    def _raise_type_error(self, expected_type, value):
+        error_message = f"Expected variable type " \
+                        f"{expected_type} but got {type(value)}"
+        self._talk_to_logger(error_message)
+        raise TypeError(error_message)
 
     @abstractmethod
     def _talk_to_logger(self, error_message):

--- a/src/main/python/resources/checkers/property_checker.py
+++ b/src/main/python/resources/checkers/property_checker.py
@@ -11,12 +11,19 @@ class PropertyChecker:
         :param expected_type: type the value should match
         :param include_none: whenever None should be allowed
         """
-        if not isinstance(value, expected_type):
-            if include_none:
-                if value is not None:
-                    self._raise_type_error(expected_type, value)
-            else:
+        if isinstance(value, bool):
+            if type(value) != expected_type:
+                self._check_none(expected_type, value, include_none)
+
+        elif not isinstance(value, expected_type):
+            self._check_none(expected_type, value, include_none)
+
+    def _check_none(self, expected_type, value, include_none):
+        if include_none:
+            if value is not None:
                 self._raise_type_error(expected_type, value)
+        else:
+            self._raise_type_error(expected_type, value)
 
     def _raise_type_error(self, expected_type, value):
         error_message = f"Expected variable type " \

--- a/src/main/python/resources/checkers/property_checker.py
+++ b/src/main/python/resources/checkers/property_checker.py
@@ -27,8 +27,8 @@ class PropertyChecker:
 
     def _raise_type_error(self, expected_type, value):
         error_message = "Expected variable type %s but got %s"
-        self._talk_to_logger(error_message, expected_type, value)
-        raise TypeError(error_message % (expected_type, value))
+        self._talk_to_logger(error_message, expected_type, type(value))
+        raise TypeError(error_message % (expected_type, type(value)))
 
     @abstractmethod
     def _talk_to_logger(self, msg, *args, **kwargs):

--- a/src/main/python/resources/checkers/property_checker_logger.py
+++ b/src/main/python/resources/checkers/property_checker_logger.py
@@ -7,5 +7,5 @@ class PropertyCheckerLogger(PropertyChecker):
         super().__init__()
         self.log = Logger().logger
 
-    def _talk_to_logger(self, error_message):
-        self.log.critical(error_message)
+    def _talk_to_logger(self, msg, *args, **kwargs):
+        self.log.critical(msg, *args, **kwargs)

--- a/src/test/python/core/test_config_reader.py
+++ b/src/test/python/core/test_config_reader.py
@@ -68,17 +68,22 @@ class TestConfigReader(unittest.TestCase):
     def test_get_default_key(self):
         print('Get default key')
         value = self.config.get_default_value(key='vepversion')
-        self.assertTrue(value is False or isinstance(value, int))
+        self.assertTrue(value is None or isinstance(value, int))
 
     def test_get_overwrite_key(self):
         print('Get overwrite key')
         value = self.config.get_overwrite_value(key='imputefile')
-        self.assertTrue(isinstance(value, str) or value is False)
+        self.assertTrue(isinstance(value, str) or value is None)
 
     def test_get_datafiles_key(self):
         print('Get CADD key')
         value = self.config.get_datafiles_value(key='reference')
-        self.assertTrue(os.path.exists(value) or value is False)
+        # Value can be either None or a path, but os.path.exists() will
+        # throw an TypeError if supplied with None.
+        try:
+            self.assertTrue(os.path.exists(value))
+        except TypeError:
+            self.assertIsNone(value)
 
     def test_get_training_key(self):
         print('Get training key')

--- a/src/test/python/core/test_input_checker.py
+++ b/src/test/python/core/test_input_checker.py
@@ -22,6 +22,12 @@ class TestInputChecker(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         print('Tearing down.')
+        dir_to_be_deleted = os.path.join(
+            get_project_root_dir(),
+            '.another_test_output'
+        )
+        if os.path.isdir(dir_to_be_deleted):
+            os.rmdir(dir_to_be_deleted)
         teardown()
 
     def setUp(self):

--- a/src/test/python/resources/test_checkers.py
+++ b/src/test/python/resources/test_checkers.py
@@ -75,10 +75,10 @@ class TestInputVersionChecker(unittest.TestCase):
         print('Overrule error')
         with self.assertRaises(InputError):
             InputVersionChecker(
-                config_vep_version=False,
-                file_vep_version=False,
-                config_grch_build=False,
-                file_grch_build=False
+                config_vep_version=None,
+                file_vep_version=None,
+                config_grch_build=None,
+                file_grch_build=None
             )
 
     def test_file_config_mismatch_vep(self):

--- a/src/test/python/resources/test_imputer.py
+++ b/src/test/python/resources/test_imputer.py
@@ -32,9 +32,9 @@ class TestImputer(unittest.TestCase):
 
     def tearDown(self):
         print('Resetting arguments.')
-        self.manager.overwrite_impute = False
-        self.manager.vep_version = False
-        self.manager.grch_build = False
+        self.manager.overwrite_impute = None
+        self.manager.vep_version = None
+        self.manager.grch_build = None
         print('Arguments reset.')
 
     def test_unit_imputation_config(self):

--- a/src/test/python/resources/test_property_checker.py
+++ b/src/test/python/resources/test_property_checker.py
@@ -49,6 +49,30 @@ class TestPropertyChecker(unittest.TestCase):
             expected_type
         )
 
+    def test_property_checker_int_bool(self):
+        print('Property checker with expected int and value is False')
+        value = False
+        expected_type = int
+        self.assertRaises(
+            TypeError,
+            self.property_checker.check_property,
+            value,
+            expected_type
+        )
+
+    def test_property_checker_int_bool_include_none(self):
+        print('Property checker with expected int, value is False and '
+              'include_none is True')
+        value = False
+        expected_type = int
+        self.assertRaises(
+            TypeError,
+            self.property_checker.check_property,
+            value,
+            expected_type,
+            True
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/python/resources/test_property_checker.py
+++ b/src/test/python/resources/test_property_checker.py
@@ -1,0 +1,54 @@
+import unittest
+from src.main.python.resources.checkers.property_checker import PropertyChecker
+
+
+class TestPropertyChecker(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        print('Setting up.')
+        cls.property_checker = PropertyChecker()
+
+    def setUp(self) -> None:
+        print('Testing case:')
+
+    def test_property_checker_correct(self):
+        print('Property checker correct (not None)')
+        value = 1.1
+        expected_type = float
+        self.property_checker.check_property(value, expected_type)
+
+    def test_property_checker_correct_with_none(self):
+        print('Property checker including None')
+        value = None
+        expected_type = float
+        self.property_checker.check_property(
+            value,
+            expected_type,
+            include_none=True
+        )
+
+    def test_property_checker_incorrect(self):
+        print('Property checker incorrect (without none)')
+        value = 1
+        expected_type = float
+        self.assertRaises(
+            TypeError,
+            self.property_checker.check_property,
+            value,
+            expected_type
+        )
+
+    def test_property_checker_incorrect_with_none(self):
+        print('Property checker incorrect including None')
+        value = None
+        expected_type = float
+        self.assertRaises(
+            TypeError,
+            self.property_checker.check_property,
+            value,
+            expected_type
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Changes

- Fixed a bug where `PropertyChecker()` would not throw a TypeError if an incorrect variable type was supplied but `include_none` was set to `True`.
- Changed the use of `False` for missing variables to `None`.

Closes #56