### PR TITLE
Fix/version validation model

### DIFF
--- a/src/molgenis/capice/cli/args_handler_predict.py
+++ b/src/molgenis/capice/cli/args_handler_predict.py
@@ -110,6 +110,14 @@ class ArgsHandlerPredict(ArgsHandlerParent):
             self.parser.error(f'Model major version {model.CAPICE_version} does not match '
                               f'with CAPICE: {__version__}!')
 
-        if model_version.group('prerelease') != capice_version.group('prerelease'):
-            self.parser.error(f'Model prerelease version {model.CAPICE_version} does not match '
-                              f'with CAPICE: {__version__}!')
+        if model_version.group('prerelease') is not None \
+                or capice_version.group('prerelease') is not None:
+            if model_version.group('minor') != capice_version.group('minor'):
+                self.parser.error(f'Model minor version {model.CAPICE_version} does not match with '
+                                  f'CAPICE: {__version__} (should match for pre-releases)!')
+            elif model_version.group('patch') != capice_version.group('patch'):
+                self.parser.error(f'Model patch version {model.CAPICE_version} does not match with '
+                                  f'CAPICE: {__version__} (should match for pre-releases)!')
+            elif model_version.group('prerelease') != capice_version.group('prerelease'):
+                self.parser.error(f'Model pre-release version {model.CAPICE_version} does not '
+                                  f'match with CAPICE: {__version__}!')

--- a/src/molgenis/capice/cli/args_handler_predict.py
+++ b/src/molgenis/capice/cli/args_handler_predict.py
@@ -7,6 +7,8 @@ from molgenis.capice.__version__ import __version__
 from molgenis.capice.main_predict import CapicePredict
 from molgenis.capice.core.capice_manager import CapiceManager
 from molgenis.capice.cli.args_handler_parent import ArgsHandlerParent
+from re import match
+from molgenis.capice.utilities.enums import Versioning
 
 
 class ArgsHandlerPredict(ArgsHandlerParent):
@@ -98,6 +100,16 @@ class ArgsHandlerPredict(ArgsHandlerParent):
                 self.parser.error(f'Unable to locate attribute {attribute} in model file!')
 
     def _validate_model_version(self, model):
-        if not model.CAPICE_version == __version__:
-            self.parser.error(f'Model version {model.CAPICE_version} '
-                              f'does not match CAPICE version: {__version__}!')
+        model_version = match(Versioning.VALIDATION_REGEX.value, model.CAPICE_version)
+        if model_version is None:
+            self.parser.error(f'Model version does not adhere to correct format: '
+                              f'{model.CAPICE_version}!')
+
+        capice_version = match(Versioning.VALIDATION_REGEX.value, __version__)
+        if model_version.group('major') != capice_version.group('major'):
+            self.parser.error(f'Model major version {model.CAPICE_version} does not match '
+                              f'with CAPICE: {__version__}!')
+
+        if model_version.group('prerelease') != capice_version.group('prerelease'):
+            self.parser.error(f'Model prerelease version {model.CAPICE_version} does not match '
+                              f'with CAPICE: {__version__}!')

--- a/src/molgenis/capice/utilities/enums.py
+++ b/src/molgenis/capice/utilities/enums.py
@@ -66,4 +66,4 @@ class UniqueSeparator(Enum):
 
 class Versioning(Enum):
     VALIDATION_REGEX = ('^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
-                        '(?P<prerelease>-[a-zA-Z0-9-]+)?$')
+                        '(-?(?P<prerelease>a|b|rc[0-9]+))?$')

--- a/src/molgenis/capice/utilities/enums.py
+++ b/src/molgenis/capice/utilities/enums.py
@@ -62,3 +62,8 @@ class UniqueSeparator(Enum):
     columns.
     """
     unique_separator = '_VeryUniqueCAPICESeparator_'
+
+
+class Versioning(Enum):
+    VALIDATION_REGEX = ('^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
+                        '(?P<prerelease>-[a-zA-Z0-9-]+)?$')

--- a/tests/capice/cli/test_args_handler_predict.py
+++ b/tests/capice/cli/test_args_handler_predict.py
@@ -27,7 +27,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
     @patch('sys.stderr', new_callable=StringIO)
     @patch.object(pickle, 'load')
     @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
-    def test_model_invalid_version(self, pickle_load, stderr):
+    def test_model_semantic_invalid_version(self, pickle_load, stderr):
         setattr(self.model, 'CAPICE_version', '1.0.0-')
         pickle_load.return_value = self.model
 
@@ -37,6 +37,21 @@ class TestArgsHandlerPredict(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
         self.assertIn('Model version does not adhere to correct format: 1.0.0-',
+                      stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
+    def test_model_pypi_invalid_prerelease_name(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.0.0pre1')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model version does not adhere to correct format: 1.0.0pre1',
                       stderr.getvalue())
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -75,7 +90,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
     @patch('sys.stderr', new_callable=StringIO)
     @patch.object(pickle, 'load')
     @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
-    def test_model_prerelease_mismatch(self, pickle_load, stderr):
+    def test_model_semantic_prerelease_mismatch(self, pickle_load, stderr):
         setattr(self.model, 'CAPICE_version', '1.0.0-rc2')
         pickle_load.return_value = self.model
 
@@ -90,7 +105,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
     @patch('sys.stderr', new_callable=StringIO)
     @patch.object(pickle, 'load')
     @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
-    def test_model_prerelease_missing_in_capice(self, pickle_load, stderr):
+    def test_model_semantic_prerelease_missing_in_capice(self, pickle_load, stderr):
         setattr(self.model, 'CAPICE_version', '1.0.0-rc1')
         pickle_load.return_value = self.model
 
@@ -105,7 +120,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
     @patch('sys.stderr', new_callable=StringIO)
     @patch.object(pickle, 'load')
     @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
-    def test_model_prerelease_missing_in_model(self, pickle_load, stderr):
+    def test_model_semantic_prerelease_missing_in_model(self, pickle_load, stderr):
         setattr(self.model, 'CAPICE_version', '1.0.0')
         pickle_load.return_value = self.model
 
@@ -115,6 +130,39 @@ class TestArgsHandlerPredict(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
         self.assertIn('Model prerelease version 1.0.0 does not match with CAPICE: 1.0.0-rc1!',
+                      stderr.getvalue())
+
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0rc1')
+    def test_model_pypi_prerelease(self, pickle_load):
+        setattr(self.model, 'CAPICE_version', '1.0.0rc1')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        args_handler.validate_model(self.model_path)
+
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
+    def test_model_semantic_and_pypi_prerelease(self, pickle_load):
+        setattr(self.model, 'CAPICE_version', '1.0.0rc1')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        args_handler.validate_model(self.model_path)
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
+    def test_model_semantic_and_pypi_prerelease_mismatch(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.0.0rc2')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model prerelease version 1.0.0rc2 does not match with CAPICE: 1.0.0-rc1!',
                       stderr.getvalue())
 
 

--- a/tests/capice/cli/test_args_handler_predict.py
+++ b/tests/capice/cli/test_args_handler_predict.py
@@ -99,7 +99,39 @@ class TestArgsHandlerPredict(unittest.TestCase):
             args_handler.validate_model(self.model_path)
 
         self.assertEqual(cm.exception.code, 2)
-        self.assertIn('Model prerelease version 1.0.0-rc2 does not match with CAPICE: 1.0.0-rc1!',
+        self.assertIn('Model pre-release version 1.0.0-rc2 does not match with CAPICE: 1.0.0-rc1!',
+                      stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
+    def test_model_semantic_prerelease_with_minor_mismatch(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.2.0-rc1')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model minor version 1.2.0-rc1 does not match with CAPICE: 1.0.0-rc1 '
+                      '(should match for pre-releases)!',
+                      stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
+    def test_model_semantic_prerelease_with_patch_mismatch(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.0.2-rc1')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model patch version 1.0.2-rc1 does not match with CAPICE: 1.0.0-rc1 '
+                      '(should match for pre-releases)!',
                       stderr.getvalue())
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -114,7 +146,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
             args_handler.validate_model(self.model_path)
 
         self.assertEqual(cm.exception.code, 2)
-        self.assertIn('Model prerelease version 1.0.0-rc1 does not match with CAPICE: 1.0.0!',
+        self.assertIn('Model pre-release version 1.0.0-rc1 does not match with CAPICE: 1.0.0!',
                       stderr.getvalue())
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -129,7 +161,22 @@ class TestArgsHandlerPredict(unittest.TestCase):
             args_handler.validate_model(self.model_path)
 
         self.assertEqual(cm.exception.code, 2)
-        self.assertIn('Model prerelease version 1.0.0 does not match with CAPICE: 1.0.0-rc1!',
+        self.assertIn('Model pre-release version 1.0.0 does not match with CAPICE: 1.0.0-rc1!',
+                      stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0rc1')
+    def test_model_pypi_prerelease_missing_in_model(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.0.0')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model pre-release version 1.0.0 does not match with CAPICE: 1.0.0rc1!',
                       stderr.getvalue())
 
     @patch.object(pickle, 'load')
@@ -162,7 +209,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
             args_handler.validate_model(self.model_path)
 
         self.assertEqual(cm.exception.code, 2)
-        self.assertIn('Model prerelease version 1.0.0rc2 does not match with CAPICE: 1.0.0-rc1!',
+        self.assertIn('Model pre-release version 1.0.0rc2 does not match with CAPICE: 1.0.0-rc1!',
                       stderr.getvalue())
 
 

--- a/tests/capice/cli/test_args_handler_predict.py
+++ b/tests/capice/cli/test_args_handler_predict.py
@@ -1,0 +1,122 @@
+import unittest
+
+import pickle
+import os
+from io import StringIO
+
+from pathlib import Path
+from unittest.mock import patch
+
+from molgenis.capice.cli.args_handler_predict import ArgsHandlerPredict
+from argparse import ArgumentParser
+
+
+_project_root_directory = Path(__file__).absolute().parent.parent.parent.parent
+
+
+class TestArgsHandlerPredict(unittest.TestCase):
+    model_path = os.path.join(_project_root_directory,
+                              'tests',
+                              'resources',
+                              'xgb_booster_poc.pickle.dat')
+
+    def setUp(self):
+        with open(self.model_path, 'rb') as model_file:
+            self.model = pickle.load(model_file)
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
+    def test_model_invalid_version(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1!0!0')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model version does not adhere to correct format: 1!0!0',
+                      stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
+    def test_model_major_mismatch(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '2.0.0')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model major version 2.0.0 does not match with CAPICE: 1.0.0!',
+                      stderr.getvalue())
+
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
+    def test_model_minor_mismatch(self, pickle_load):
+        setattr(self.model, 'CAPICE_version', '1.2.0')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        args_handler.validate_model(self.model_path)
+
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
+    def test_model_patch_mismatch(self, pickle_load):
+        setattr(self.model, 'CAPICE_version', '1.0.2')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        args_handler.validate_model(self.model_path)
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
+    def test_model_prerelease_mismatch(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.0.0-rc2')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model prerelease version 1.0.0-rc2 does not match with CAPICE: 1.0.0-rc1!',
+                      stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
+    def test_model_prerelease_missing_in_capice(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.0.0-rc1')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model prerelease version 1.0.0-rc1 does not match with CAPICE: 1.0.0!',
+                      stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch.object(pickle, 'load')
+    @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0-rc1')
+    def test_model_prerelease_missing_in_model(self, pickle_load, stderr):
+        setattr(self.model, 'CAPICE_version', '1.0.0')
+        pickle_load.return_value = self.model
+
+        args_handler = ArgsHandlerPredict(ArgumentParser())
+        with self.assertRaises(SystemExit) as cm:
+            args_handler.validate_model(self.model_path)
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn('Model prerelease version 1.0.0 does not match with CAPICE: 1.0.0-rc1!',
+                      stderr.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/capice/cli/test_args_handler_predict.py
+++ b/tests/capice/cli/test_args_handler_predict.py
@@ -28,7 +28,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
     @patch.object(pickle, 'load')
     @patch('molgenis.capice.cli.args_handler_predict.__version__', '1.0.0')
     def test_model_invalid_version(self, pickle_load, stderr):
-        setattr(self.model, 'CAPICE_version', '1!0!0')
+        setattr(self.model, 'CAPICE_version', '1.0.0-')
         pickle_load.return_value = self.model
 
         args_handler = ArgsHandlerPredict(ArgumentParser())
@@ -36,7 +36,7 @@ class TestArgsHandlerPredict(unittest.TestCase):
             args_handler.validate_model(self.model_path)
 
         self.assertEqual(cm.exception.code, 2)
-        self.assertIn('Model version does not adhere to correct format: 1!0!0',
+        self.assertIn('Model version does not adhere to correct format: 1.0.0-',
                       stderr.getvalue())
 
     @patch('sys.stderr', new_callable=StringIO)

--- a/tests/capice/test__version__.py
+++ b/tests/capice/test__version__.py
@@ -1,0 +1,15 @@
+import unittest
+
+from molgenis.capice.utilities.enums import Versioning
+from src.molgenis.capice.__version__ import __version__
+from re import match
+
+
+class TestVersion(unittest.TestCase):
+    def test_version_formatting(self):
+        if match(Versioning.VALIDATION_REGEX.value, __version__) is None:
+            raise ValueError('CAPICE has invalid version format')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## SOP

### Changed
- Model/CAPICE version validation is now based on major version only (except for pre-releases).

## Important notes
- For non-RC releases: Compares on major-version only.
- If either CAPICE or model has a pre-release version: Minor, patch & pre-release should match as well (if `1.0.0-rc1` should cause an error with `1.0.0-rc2`, than it seems logical `1.0.0-rc1` should fail with `1.2.0-rc1` as well).
- Regex currently supports major.minor.patch-prerelease based on semantic & PyPi versioning, though expects PyPi pre-release versioning as this is the most strict (a|b|rc[0-9]+).
- See also unit-tests which covers several scenario's regarding what is accepted and what fails.

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
