### PR TITLE
fix: Default output argument

### DIFF
--- a/src/molgenis/capice/utilities/input_processor.py
+++ b/src/molgenis/capice/utilities/input_processor.py
@@ -43,7 +43,7 @@ class InputProcessor:
             self._set_output_path(self.call_dir, filename)
         else:
             # Check if it is a path or else just a filename
-            if len(os.path.dirname(self.output_path)) > 0:
+            if len(os.path.dirname(self.output_path)) > 0 or self.output_path == '.':
                 # Then I know it's an output filepath + possibly name
                 if os.path.splitext(self.output_path)[1] != '':
                     # Then I know it is a full path + filename

--- a/tests/capice/utilities/test_input_processor.py
+++ b/tests/capice/utilities/test_input_processor.py
@@ -80,6 +80,18 @@ class TestInputProcessor(unittest.TestCase):
         self.assertEqual('/directory', self.processor.get_output_directory())
         self.assertEqual('file.txt', self.processor.get_output_filename())
 
+    def test___handle_input_output_directories_case5(self):
+        self.processor.output_path = '.'
+        self.processor._handle_input_output_directories()
+        self.assertEqual('.', self.processor.get_output_directory())
+        self.assertEqual(self.__FILE__, self.processor.get_output_filename())
+
+    def test___handle_input_output_directories_case6(self):
+        self.processor.output_path = './file.txt'
+        self.processor._handle_input_output_directories()
+        self.assertEqual('.', self.processor.get_output_directory())
+        self.assertEqual('file.txt', self.processor.get_output_filename())
+
     def test_force_false_output_missing_output_exists(self):
         # This test mimics what happens when output is left empty from the CLI
         # and the output file + _capice + default_extension already exists


### PR DESCRIPTION
## SOP

### Changed

- Fixed a bug that is caused by supplying `-o .` to the command line
arguments of CAPICE that would raise an error that the incorrect file
extension was supplied.

## Important notes

- Closes #103 
- Once both #104 and #105 have been merged, release CAPICE 3.1.1

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
