### PR TITLE
fix(tests):ignore dtype in assert_frame_equal

### DIFF
--- a/tests/capice/utilities/test_manual_vep_processor.py
+++ b/tests/capice/utilities/test_manual_vep_processor.py
@@ -108,8 +108,10 @@ class TestAnnotator(unittest.TestCase):
             ], axis=1
         )
         outcome = self.annotator.process(self.dataset)
+        # if numpy.array dtype not given, then the type will be determined as the minimum type required to hold the
+        # objects in the sequence. this minimal type is system dependent.
         pd.testing.assert_frame_equal(
-            expected_outcome.sort_index(axis=1), outcome.sort_index(axis=1)
+            expected_outcome.sort_index(axis=1), outcome.sort_index(axis=1), check_dtype=False
         )
 
     def test_bug_attributeerror_template_sift_polyphen(self):

--- a/tests/capice/utilities/test_manual_vep_processor.py
+++ b/tests/capice/utilities/test_manual_vep_processor.py
@@ -108,7 +108,8 @@ class TestAnnotator(unittest.TestCase):
             ], axis=1
         )
         outcome = self.annotator.process(self.dataset)
-        # if numpy.array dtype not given, then the type will be determined as the minimum type required to hold the
+        # if numpy.array dtype not given,
+        # then the type will be determined as the minimum type required to hold the
         # objects in the sequence. this minimal type is system dependent.
         pd.testing.assert_frame_equal(
             expected_outcome.sort_index(axis=1), outcome.sort_index(axis=1), check_dtype=False

--- a/tests/capice/vep/test_consequence.py
+++ b/tests/capice/vep/test_consequence.py
@@ -60,7 +60,9 @@ class TestConsequence(unittest.TestCase):
                 )
             ], axis=1
         )
-        pd.testing.assert_frame_equal(observerd.sort_index(axis=1), expected.sort_index(axis=1))
+        # if numpy.array dtype not given, then the type will be determined as the minimum type required to hold the
+        # objects in the sequence. this minimal type is system dependent.
+        pd.testing.assert_frame_equal(observerd.sort_index(axis=1), expected.sort_index(axis=1), check_dtype=False)
 
 
 if __name__ == '__main__':

--- a/tests/capice/vep/test_consequence.py
+++ b/tests/capice/vep/test_consequence.py
@@ -60,9 +60,11 @@ class TestConsequence(unittest.TestCase):
                 )
             ], axis=1
         )
-        # if numpy.array dtype not given, then the type will be determined as the minimum type required to hold the
+        # if numpy.array dtype not given,
+        # then the type will be determined as the minimum type required to hold the
         # objects in the sequence. this minimal type is system dependent.
-        pd.testing.assert_frame_equal(observerd.sort_index(axis=1), expected.sort_index(axis=1), check_dtype=False)
+        pd.testing.assert_frame_equal(observerd.sort_index(axis=1), expected.sort_index(axis=1),
+                                      check_dtype=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## SOP

### Changed

-

## Important notes

-

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
