### PR TITLE
fix: Hardcoded threads

### DIFF
--- a/src/molgenis/capice/cli/args_handler_train.py
+++ b/src/molgenis/capice/cli/args_handler_train.py
@@ -1,5 +1,4 @@
 import os
-import multiprocessing as mp
 
 from molgenis.capice.main_train import CapiceTrain
 from molgenis.capice.core.capice_manager import CapiceManager

--- a/src/molgenis/capice/main_train.py
+++ b/src/molgenis/capice/main_train.py
@@ -17,7 +17,7 @@ class CapiceTrain(Main):
     use cases.
     """
 
-    def __init__(self, input_path, json_path, test_split, output_path):
+    def __init__(self, input_path, json_path, test_split, output_path, threads):
         super().__init__(input_path, output_path)
 
         # Impute JSON.
@@ -36,7 +36,7 @@ class CapiceTrain(Main):
 
         # Variables that can be edited in testing to speed up the train testing
         self.esr = 15
-        self.n_jobs = 8
+        self.n_jobs = threads
         self.cross_validate = 5
         self.n_iterations = 20
 

--- a/tests/capice/cli/test_args_handler_train.py
+++ b/tests/capice/cli/test_args_handler_train.py
@@ -1,0 +1,54 @@
+import argparse
+import os
+import unittest
+
+from io import StringIO
+from unittest.mock import patch
+
+from molgenis.capice.cli.args_handler_train import ArgsHandlerTrain
+
+
+class TestArgsHandlerPredict(unittest.TestCase):
+
+    def setUp(self):
+        parser = argparse.ArgumentParser(
+            description="CAPICE test"
+        )
+        self.aht = ArgsHandlerTrain(parser)
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_validate_input_json_path(self, stderr):
+        with self.assertRaises(SystemExit):
+            self.aht.validate_input_json('this/path/doesnt/exist.json')
+        self.assertIn('Input JSON does not exist!', stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_validate_input_json_json(self, stderr):
+        # When running test in PyCharm, set working dir to root of capice to match pytest and travis
+        if os.getcwd().endswith('cli'):
+            os.chdir('../../..')
+        with self.assertRaises(SystemExit):
+            self.aht.validate_input_json('setup.py')
+        self.assertIn('Given input JSON is not a JSON file!', stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_validate_n_threads(self, stderr):
+        with self.assertRaises(SystemExit):
+            self.aht.validate_n_threads(0)
+        self.assertIn('The amount of threads has to be at least 1!', stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_validate_test_split_0(self, stderr):
+        with self.assertRaises(SystemExit):
+            self.aht.validate_test_split(0)
+        self.assertIn('Test split must be a float between 0 and 1', stderr.getvalue())
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_validate_test_split_1(self, stderr):
+        with self.assertRaises(SystemExit):
+            self.aht.validate_test_split(1)
+        self.assertIn('Test split must be a float between 0 and 1', stderr.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/capice/cli/test_args_handler_train.py
+++ b/tests/capice/cli/test_args_handler_train.py
@@ -4,6 +4,7 @@ import unittest
 
 from io import StringIO
 from unittest.mock import patch
+from tests.capice.test_templates import _project_root_directory
 
 from molgenis.capice.cli.args_handler_train import ArgsHandlerTrain
 
@@ -24,11 +25,8 @@ class TestArgsHandlerPredict(unittest.TestCase):
 
     @patch('sys.stderr', new_callable=StringIO)
     def test_validate_input_json_json(self, stderr):
-        # When running test in PyCharm, set working dir to root of capice to match pytest and travis
-        if os.getcwd().endswith('cli'):
-            os.chdir('../../..')
         with self.assertRaises(SystemExit):
-            self.aht.validate_input_json('setup.py')
+            self.aht.validate_input_json(os.path.join(_project_root_directory, 'setup.py'))
         self.assertIn('Given input JSON is not a JSON file!', stderr.getvalue())
 
     @patch('sys.stderr', new_callable=StringIO)

--- a/tests/capice/test_main_train.py
+++ b/tests/capice/test_main_train.py
@@ -20,9 +20,9 @@ class TestMainTrain(unittest.TestCase):
         cls.main = CapiceTrain(input_path=train_file,
                                json_path=impute_json,
                                test_split=0.2,
-                               output_path=cls.output_dir)
+                               output_path=cls.output_dir,
+                               threads=2)
         cls.main.esr = 1
-        cls.main.n_jobs = 2
         cls.main.cross_validate = 2
         cls.main.n_iterations = 2
 


### PR DESCRIPTION
## SOP

### Changed

- Fixes an issue where the amount of threads that XGBoost could use to train was hardcoded. The user can now set that amount themselves, although limited to at least 1.

## Important notes

- Closes #112

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
