### PR TITLE
fix: README VEP duplicate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ command:
 vep --input_file <path to your input file> --format vcf --output_file <path to your output file> --vcf --compress_output gzip --force_overwrite 
 --sift s --polyphen s --numbers --symbol --shift_3prime 1 --allele_number --refseq --total_length  
 --no_stats --offline --cache --dir_cache </path/to/cache/105> --species "homo_sapiens" --assembly <GRCh37 or GRCh38> --fork 4 
---dont_skip --allow_non_variant --use_given_ref --exclude_predicted --use_given_ref --flag_pick_allele
+--dont_skip --allow_non_variant --use_given_ref --exclude_predicted --flag_pick_allele
 --plugin SpliceAI,snv=<path/to/raw_scores_snv.vcf.gz>,indel=</path/to/raw_scores_indel.vcf.gz> --dir_plugins <path to your VEP plugin directory>
 ```
 


### PR DESCRIPTION
## SOP

### Changed

- Fixed a documentation issue where flag `--use_given_ref` was supplied twice.

## Important notes

-

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
