### PR TITLE
docs: Conversion script pointer

### DIFF
--- a/src/molgenis/capice/core/args_handler.py
+++ b/src/molgenis/capice/core/args_handler.py
@@ -21,7 +21,7 @@ class ArgsHandler:
         self.version = __version__
         self.parser = argparse.ArgumentParser(
             description=f"CAPICE, a machine-learning-based method for prioritizing pathogenic"
-                        f" variants https://doi.org/10.1186/s13073-020-00775-w ."
+                        f" variants (https://doi.org/10.1186/s13073-020-00775-w). "
                         f"Converting a VEP output VCF can be done using the conversion tool "
                         f"supplied here: {link} (requires Apptainer)."
         )

--- a/src/molgenis/capice/core/args_handler.py
+++ b/src/molgenis/capice/core/args_handler.py
@@ -16,10 +16,14 @@ class ArgsHandler:
     """
 
     def __init__(self):
+        link = "https://github.com/molgenis/capice/blob/main/scripts/" \
+               "convert_vep_vcf_to_tsv_capice.sh"
         self.version = __version__
         self.parser = argparse.ArgumentParser(
-            description="CAPICE, a machine-learning-based method for prioritizing pathogenic"
-                        " variants https://doi.org/10.1186/s13073-020-00775-w"
+            description=f"CAPICE, a machine-learning-based method for prioritizing pathogenic"
+                        f" variants https://doi.org/10.1186/s13073-020-00775-w ."
+                        f"Converting a VEP output VCF can be done using the conversion tool "
+                        f"supplied here: {link} (requires Apptainer)."
         )
         self.manager = CapiceManager()
 


### PR DESCRIPTION
## SOP

### Changed

- Added link to `capice -h` to point toward the Apptainer VEP VCF to TSV conversion script.

## Important notes

-

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
