### PR TITLE
fix: Output overwrite without force

### DIFF
--- a/src/molgenis/capice/cli/args_handler_explain.py
+++ b/src/molgenis/capice/cli/args_handler_explain.py
@@ -54,4 +54,4 @@ class ArgsHandlerExplain(ArgsHandlerParent):
         validator = ModelValidator()
         validator.validate_has_required_attributes(model)
         CapiceManager().output_filename = output_filename
-        CapiceExplain(model, output_path, output_given).run()
+        CapiceExplain(model, output_path, output_given, self.force).run()

--- a/src/molgenis/capice/cli/args_handler_parent.py
+++ b/src/molgenis/capice/cli/args_handler_parent.py
@@ -17,6 +17,7 @@ class ArgsHandlerParent(metaclass=ABCMeta):
     def __init__(self, parser):
         self.parser = parser
         self.input_validator = InputValidator()
+        self.force = False
 
     @property
     @abstractmethod
@@ -91,11 +92,12 @@ class ArgsHandlerParent(metaclass=ABCMeta):
         except FileNotFoundError as cm:
             self.parser.error(str(cm))
         output_path = self._retrieve_argument_from_list(args.output, '-o/--output')
+        self.force = args.force
         try:
             processor = InputProcessor(
                 input_path=input_path,
                 output_path=output_path,
-                force=args.force,
+                force=self.force,
                 default_extension=self._empty_output_extension
             )
         except FileExistsError as cm:

--- a/src/molgenis/capice/cli/args_handler_predict.py
+++ b/src/molgenis/capice/cli/args_handler_predict.py
@@ -71,7 +71,7 @@ class ArgsHandlerPredict(ArgsHandlerParent):
         model_path = self._retrieve_argument_from_list(args.model, '-m/--model')
         model = self.validate_model(model_path)
         CapiceManager().output_filename = output_filename
-        CapicePredict(input_path, model, output_path, output_given).run()
+        CapicePredict(input_path, model, output_path, output_given, self.force).run()
 
     def validate_model(self, model_path):
         """

--- a/src/molgenis/capice/cli/args_handler_train.py
+++ b/src/molgenis/capice/cli/args_handler_train.py
@@ -96,7 +96,15 @@ class ArgsHandlerTrain(ArgsHandlerParent):
         self.validate_n_threads(n_threads)
 
         CapiceManager().output_filename = output_filename
-        CapiceTrain(input_path, features, test_split, output_path, output_given, n_threads).run()
+        CapiceTrain(
+            input_path,
+            features,
+            test_split,
+            output_path,
+            output_given,
+            self.force,
+            n_threads
+        ).run()
 
     def validate_n_threads(self, n_threads):
         """

--- a/src/molgenis/capice/core/capice_exporter.py
+++ b/src/molgenis/capice/core/capice_exporter.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from molgenis.capice.core.logger import Logger
 from molgenis.capice.core.capice_manager import CapiceManager
+from molgenis.capice.utilities import check_file_exist
 from molgenis.capice.utilities.enums import Column, UniqueSeparator
 
 
@@ -12,11 +13,12 @@ class CapiceExporter:
     Class specifically exporting files
     """
 
-    def __init__(self, file_path, output_given):
+    def __init__(self, file_path, output_given, force):
         self.log = Logger().logger
         self.capice_filename = CapiceManager().output_filename
         self.file_path = file_path
         self.output_given = output_given
+        self.force = force
         self.export_cols = [
             Column.chr.value,
             Column.pos.value,
@@ -40,6 +42,7 @@ class CapiceExporter:
         export_path = os.path.join(self.file_path, self.capice_filename)
         datafile = self._post_process_split_cols(datafile)
         datafile = self._post_process_set_correct_dtypes(datafile)
+        check_file_exist(export_path, self.force)
         datafile[self.export_cols].to_csv(export_path, sep='\t', index=False)
         if not self.output_given:
             print('Successfully exported CAPICE datafile to: %s', export_path)
@@ -63,6 +66,7 @@ class CapiceExporter:
         :param model: XGBClassifier instance
         """
         export_path = os.path.join(self.file_path, self.capice_filename)
+        check_file_exist(export_path, self.force)
         model.save_model(export_path)
         if not self.output_given:
             print('Successfully exported CAPICE model to: ', export_path)

--- a/src/molgenis/capice/main_capice.py
+++ b/src/molgenis/capice/main_capice.py
@@ -20,7 +20,7 @@ class Main(ABC):
     function.
     """
 
-    def __init__(self, input_path, output_path, output_given):
+    def __init__(self, input_path, output_path, output_given, force):
         # Assumes CapiceManager has been initialized & filled.
         self.manager = CapiceManager()
         self.log = Logger().logger
@@ -35,6 +35,9 @@ class Main(ABC):
         self.output = output_path
         self.log.debug('Output directory -o / --output confirmed: %s', self.output)
         self.output_given = output_given
+
+        self.force = force
+        self.log.debug('Force output if exists: %s', self.force)
 
         # Preprocessor global exclusion features
         # Overwrite in specific module if features are incorrect
@@ -121,5 +124,8 @@ class Main(ABC):
         """
         Function to prepare the data to be exported
         """
-        CapiceExporter(file_path=output, output_given=self.output_given).export_capice_prediction(
-            datafile=dataset)
+        CapiceExporter(
+            file_path=output,
+            output_given=self.output_given,
+            force=self.force
+        ).export_capice_prediction(datafile=dataset)

--- a/src/molgenis/capice/main_explain.py
+++ b/src/molgenis/capice/main_explain.py
@@ -5,12 +5,18 @@ import xgboost as xgb
 
 from molgenis.capice.main_capice import Main
 from molgenis.capice.core.logger import Logger
+from molgenis.capice.utilities import check_file_exist
 from molgenis.capice.core.capice_manager import CapiceManager
 
 
 class CapiceExplain(Main):
-    def __init__(self, model, output_path, output_given):
-        super().__init__(input_path=None, output_path=output_path, output_given=output_given)
+    def __init__(self, model, output_path, output_given, force):
+        super().__init__(
+            input_path=None,
+            output_path=output_path,
+            output_given=output_given,
+            force=force
+        )
         self.model = model
         self.output = output_path
         self.log = Logger().logger
@@ -83,6 +89,7 @@ class CapiceExplain(Main):
 
     def _export(self, dataset, output):
         output_path = os.path.join(output, CapiceManager().output_filename)
+        check_file_exist(output_path, self.force)
         dataset.to_csv(output_path, compression='gzip', index=False, sep='\t')
         if not self.output_given:
             print(f'Successfully exported explain to: {output_path}')

--- a/src/molgenis/capice/main_predict.py
+++ b/src/molgenis/capice/main_predict.py
@@ -12,8 +12,13 @@ class CapicePredict(Main):
     process and eventually predict a score over a CAPICE annotated file.
     """
 
-    def __init__(self, input_path, model, output_path, output_given):
-        super().__init__(input_path, output_path, output_given)
+    def __init__(self, input_path, model, output_path, output_given, force):
+        super().__init__(
+            input_path,
+            output_path,
+            output_given,
+            force
+        )
 
         # Model.
         self.model = model

--- a/src/molgenis/capice/main_train.py
+++ b/src/molgenis/capice/main_train.py
@@ -19,8 +19,22 @@ class CapiceTrain(Main):
     use cases.
     """
 
-    def __init__(self, input_path, json_path, test_split, output_path, output_given, threads):
-        super().__init__(input_path, output_path, output_given)
+    def __init__(
+            self,
+            input_path,
+            json_path,
+            test_split,
+            output_path,
+            output_given,
+            force,
+            threads
+    ):
+        super().__init__(
+            input_path,
+            output_path,
+            output_given,
+            force
+        )
 
         # Impute JSON.
         self.json_path = json_path
@@ -49,7 +63,11 @@ class CapiceTrain(Main):
         self.model_random_state = 0
         self.train_features = []
         self.loglevel = self.manager.loglevel
-        self.exporter = CapiceExporter(file_path=self.output, output_given=self.output_given)
+        self.exporter = CapiceExporter(
+            file_path=self.output,
+            output_given=self.output_given,
+            force=self.force
+        )
 
     def run(self):
         """

--- a/src/molgenis/capice/utilities/__init__.py
+++ b/src/molgenis/capice/utilities/__init__.py
@@ -1,3 +1,4 @@
+import os
 import functools
 import warnings
 from pathlib import Path
@@ -52,3 +53,20 @@ def check_if_in_list(list_of_lists: list[list[object]], to_check_list: Iterable)
             if item not in to_check_list:
                 return_list.append(item)
     return return_list
+
+
+def check_file_exist(file_path: os.PathLike[str], force: bool):
+    """
+    Method to check if a file exists and (if force is set to False) raises FileExistsError.
+    If force is set to True, will not raise FileExistsError. Will also not raise FileExistsError
+    if file not exists.
+
+    Args:
+        file_path:
+            Full absolute output path, including the output filename and extension.
+        force:
+            Command Line Argument of the "force" argument.
+
+    """
+    if os.path.exists(file_path) and not force:
+        raise FileExistsError("Output file already exists!")

--- a/src/molgenis/capice/utilities/input_processor.py
+++ b/src/molgenis/capice/utilities/input_processor.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+from molgenis.capice.utilities import check_file_exist
+
 
 class InputProcessor:
     def __init__(self, input_path, output_path, force, default_extension):
@@ -63,9 +65,7 @@ class InputProcessor:
 
     def _check_force(self):
         full_output_path = os.path.join(self.output_directory, self.output_filename)
-        if not self.force and os.path.isfile(full_output_path):
-            raise FileExistsError(
-                f'Output file {full_output_path} already exists! Use -f / --force to overwrite.')
+        check_file_exist(full_output_path, self.force)
 
     def _set_output_path(self, directory, filename):
         self.output_directory = directory

--- a/tests/capice/cli/test_args_handler_predict.py
+++ b/tests/capice/cli/test_args_handler_predict.py
@@ -1,18 +1,24 @@
+import os
 import unittest
 from unittest.mock import patch
 from io import StringIO
 from argparse import ArgumentParser
 
 from molgenis.capice.cli.args_handler_parent import ArgsHandlerParent
-from tests.capice.test_templates import ResourceFile
+from tests.capice.test_templates import ResourceFile, _project_test_resources
 from molgenis.capice.cli.args_handler_predict import ArgsHandlerPredict
 
 
 class TestArgsHandlerPredict(unittest.TestCase):
     model_path = ResourceFile.XGB_BOOSTER_POC_UBJ.value
+    temp_output_path = os.path.join(_project_test_resources, 'output.tsv.gz')
 
     def setUp(self):
         self.model = ArgsHandlerParent.load_model(self.model_path)
+
+    def tearDown(self) -> None:
+        if os.path.isfile(self.temp_output_path):
+            os.remove(self.temp_output_path)
 
     @patch('sys.stderr', new_callable=StringIO)
     @patch.object(ArgsHandlerPredict, 'load_model')

--- a/tests/capice/core/test_capice_exporter.py
+++ b/tests/capice/core/test_capice_exporter.py
@@ -13,8 +13,6 @@ class TestCapiceExporter(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         print('Setting up.')
-        manager, cls.output_path = set_up_manager_and_out()
-        cls.exporter = CapiceExporter(file_path=cls.output_path, output_given=True)
         cls.prediction_output_dataframe = pd.DataFrame(
             {
                 Column.chr_pos_ref_alt.value: [
@@ -65,6 +63,8 @@ class TestCapiceExporter(unittest.TestCase):
 
     def setUp(self):
         print('Testing case:')
+        manager, self.output_path = set_up_manager_and_out()
+        self.exporter = CapiceExporter(file_path=self.output_path, output_given=True, force=False)
 
     def test_prediction_output(self):
         print('Prediction output')
@@ -77,7 +77,7 @@ class TestCapiceExporter(unittest.TestCase):
         exported_data[Column.chr.value] = exported_data[Column.chr.value].astype(str)
         pd.testing.assert_frame_equal(exported_data, self.expected_prediction_output_dataframe)
 
-    def test_exporter_force(self):
+    def test_exporter_force_pass(self):
         """
         Since force is dealt with at the very start of CAPICE and raises an
         error if the output file is already present unless the force flag is
@@ -89,6 +89,7 @@ class TestCapiceExporter(unittest.TestCase):
         with open(present_file_path, 'wt') as present_file_conn:
             present_file_conn.write('This file is already present')
         self.exporter.capice_filename = present_file
+        self.exporter.force = True
         self.exporter.export_capice_prediction(datafile=self.prediction_output_dataframe)
         forced_file = pd.read_csv(present_file_path, sep='\t')
         forced_file[Column.chr.value] = forced_file[Column.chr.value].astype(str)

--- a/tests/capice/test_main_explain.py
+++ b/tests/capice/test_main_explain.py
@@ -28,7 +28,12 @@ class TestCapiceExplain(unittest.TestCase):
             os.rmdir(cls.output_path)
 
     def test_capice_explain(self):
-        explainer = CapiceExplain(model=self.model, output_path=self.output_path, output_given=True)
+        explainer = CapiceExplain(
+            model=self.model,
+            output_path=self.output_path,
+            output_given=True,
+            force=False
+        )
         explainer.run()
         feature_importances = self.model.get_booster().get_score(importance_type='gain')
         observed = pd.read_csv(self.full_output_path, sep='\t')
@@ -47,8 +52,6 @@ class TestCapiceExplain(unittest.TestCase):
             importance_type='cover'))
         expected['total_cover'] = expected['feature'].map(self.model.get_booster().get_score(
             importance_type='total_cover'))
-        print(expected)
-        print(observed)
         pd.testing.assert_frame_equal(observed, expected)
 
 

--- a/tests/capice/test_main_predict.py
+++ b/tests/capice/test_main_predict.py
@@ -29,15 +29,15 @@ class TestMainNonTrain(unittest.TestCase):
         print('Main no-train (integration)')
         infile = os.path.join(_project_root_directory, 'resources', 'predict_input.tsv.gz')
         predict = CapicePredict(input_path=infile, model=self.model, output_path=self.output_dir,
-                                output_given=True)
+                                output_given=True, force=False)
         predict.run()
         prediction_output = pd.read_csv(os.path.join(self.output_dir, 'test_output.tsv'), sep='\t')
         self.assertEqual(prediction_output.shape, (4, 11))
         self.assertListEqual(
             list(prediction_output.columns),
             [
-                'chr', 'pos', 'ref', 'alt', 'gene_name', 'gene_id', 'id_source', 'feature', 'feature_type', 'score',
-                'suggested_class'
+                'chr', 'pos', 'ref', 'alt', 'gene_name', 'gene_id', 'id_source', 'feature',
+                'feature_type', 'score', 'suggested_class'
             ]
         )
 

--- a/tests/capice/test_main_train.py
+++ b/tests/capice/test_main_train.py
@@ -14,7 +14,7 @@ class TestMainTrain(unittest.TestCase):
     def setUpClass(cls):
         print('Setting up.')
         manager, cls.output_dir = set_up_manager_and_out()
-        cls.output_filename = 'train_example_capice.pickle.dat'
+        cls.output_filename = 'train_example_capice.ubj'
         manager.output_filename = cls.output_filename
 
     @classmethod
@@ -24,6 +24,9 @@ class TestMainTrain(unittest.TestCase):
 
     def tearDown(self):
         print('Resetting arguments.')
+        output_file = os.path.join(self.output_dir, self.output_filename)
+        if os.path.exists(output_file):
+            os.remove(output_file)
 
     def setUp(self):
         print('Performing test:')
@@ -31,12 +34,15 @@ class TestMainTrain(unittest.TestCase):
         impute_json = os.path.join(_project_root_directory,
                                    'resources',
                                    'train_features.json')
-        self.main = CapiceTrain(input_path=train_file,
-                                json_path=impute_json,
-                                test_split=0.2,
-                                output_path=self.output_dir,
-                                threads=2,
-                                output_given=True)
+        self.main = CapiceTrain(
+            input_path=train_file,
+            json_path=impute_json,
+            test_split=0.2,
+            output_path=self.output_dir,
+            threads=2,
+            output_given=True,
+            force=False
+        )
         self.main.esr = 1
         self.main.n_jobs = 2
         self.main.cross_validate = 2

--- a/tests/capice/test_templates.py
+++ b/tests/capice/test_templates.py
@@ -9,7 +9,7 @@ from molgenis.capice.main_predict import CapicePredict
 
 _project_root_directory = Path(__file__).absolute().parent.parent.parent
 _project_resources = os.path.join(_project_root_directory, 'resources')
-_project_test_resources = os.path.join(_project_root_directory, 'tests/resources')
+_project_test_resources = os.path.join(_project_root_directory, 'tests', 'resources')
 
 
 def set_up_manager_and_out():
@@ -42,7 +42,13 @@ def teardown():
 
 
 def set_up_predict():
-    return CapicePredict(input_path=None, model=None, output_path=None, output_given=False)
+    return CapicePredict(
+        input_path=None,
+        model=None,
+        output_path=None,
+        output_given=False,
+        force=False
+    )
 
 
 def set_up_impute_preprocess():


### PR DESCRIPTION
## SOP

### Changed

- Fixed a bug where the output of explain, predict or train could be overwritten even if force was not enabled.

## Important notes

Closes #164

### Before merge:
- [ ] Functionality works & meets specs
- [ ] No Travis issues
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
