### PR TITLE
Fix for multithreading not adhering to set value (also increases train speed).

### DIFF
--- a/src/molgenis/capice/main_train.py
+++ b/src/molgenis/capice/main_train.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import numpy as np
 import pandas as pd
@@ -18,6 +19,10 @@ class CapiceTrain(Main):
     Train class of CAPICE to create new CAPICE like models for new or specific
     use cases.
     """
+    # Xgboost uses OpenMP for multithreading. However, using n_jobs/nthread in XGBClassifier
+    # doesn't respect the set value. Current approach is to disable multithreading for OpenMP and
+    # parallelize through RandomizedSearchCV's n_jobs parameter.
+    os.environ["OMP_THREAD_LIMIT"] = "1"
 
     def __init__(self, input_path, json_path, test_split, output_path, output_given, threads):
         super().__init__(input_path, output_path, output_given)
@@ -218,7 +223,7 @@ class CapiceTrain(Main):
         model_estimator = xgb.XGBClassifier(
             verbosity=verbosity,
             objective='binary:logistic',
-            booster='gbtree', n_jobs=self.n_jobs,
+            booster='gbtree',
             min_child_weight=1,
             max_delta_step=0,
             subsample=1, colsample_bytree=1,
@@ -237,7 +242,7 @@ class CapiceTrain(Main):
         )
         randomised_search_cv = RandomizedSearchCV(estimator=model_estimator,
                                                   param_distributions=param_dist,
-                                                  scoring='roc_auc', n_jobs=8,
+                                                  scoring='roc_auc', n_jobs=self.n_jobs,
                                                   cv=self.cross_validate,
                                                   n_iter=self.n_iterations,
                                                   verbose=verbosity)


### PR DESCRIPTION
## SOP

### Changed
- Multithreading didn't respect `-t` argument. Should now behave better.

## Important notes
Tested on M1 Pro chip containing the following number of CPUs:
```bash
$ sysctl hw.physicalcpu hw.logicalcpu
hw.physicalcpu: 8
hw.logicalcpu: 8
```

Using the following command:
```bash
gtime -f '%Uuser %Ssystem %Eelapsed - %PCPU %Mmaxresident(KB)' capice train -i ./resources/train_input.tsv.gz -e ./resources/train_features.json -o ~/Desktop/test123 -f -t <number>
```


Results:
``` bash
# pre-fix (-t 4)
99.35user 41.63system 0:24.69elapsed - 570%CPU 186176maxresident(KB)
115.67user 43.19system 0:34.79elapsed - 456%CPU 182112maxresident(KB)
126.96user 39.14system 0:43.59elapsed - 381%CPU 174256maxresident(KB)

# pre-fix (-t 8)
234.79user 107.83system 1:29.85elapsed - 381%CPU 186048maxresident(KB)
183.78user 95.43system 0:56.02elapsed - 498%CPU 173200maxresident(KB)
189.06user 98.84system 0:57.57elapsed - 500%CPU 186864maxresident(KB)

# post-fix (-t 4)
40.29user 2.98system 0:10.85elapsed - 398%CPU 179200maxresident(KB)
35.10user 3.61system 0:09.96elapsed - 388%CPU 189328maxresident(KB)
32.96user 3.78system 0:09.26elapsed - 396%CPU 183392maxresident(KB)

# post-fix (-t 8)
43.00user 4.20system 0:07.43elapsed - 634%CPU 176912maxresident(KB)
41.85user 2.27system 0:07.06elapsed - 624%CPU 182224maxresident(KB)
45.51user 2.49system 0:08.30elapsed - 577%CPU 183856maxresident(KB)
```

### Before merge:
- [ ] Functionality works & meets specs
- [x] No Travis issues
- [x] Code reviewed
- [N.A.] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes
- [ ] Removed merged branches
